### PR TITLE
Added ability to have better data recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 * Cookie tracking - Yes
 * Request actual DA page for data - No
 * Clearly defined data within a row - No but reasonable
+* Limited to 10 pages only
 
 Setup MORPH_PERIOD for data recovery, available options are
 
 * not set = past 14 days (default)
 * thismonth
 * lastmonth
-* thisyear
-* lastyear
+* custom [201808] for 2018 August

--- a/scraper.rb
+++ b/scraper.rb
@@ -2,10 +2,6 @@ require 'scraperwiki'
 require 'mechanize'
 
 case ENV['MORPH_PERIOD']
-  when 'lastyear'
-    period = (Date.today-365).strftime("1/1/%Y")+'&2='+(Date.today-365).strftime("31/12/%Y")
-  when 'thisyear'
-    period = (Date.today).strftime("1/1/%Y")+'&2='+(Date.today).strftime("31/12/%Y")
   when 'lastmonth'
     period = 'lastmonth'
   when 'thismonth'

--- a/scraper.rb
+++ b/scraper.rb
@@ -2,12 +2,34 @@ require 'scraperwiki'
 require 'mechanize'
 
 case ENV['MORPH_PERIOD']
+  when /^([2][0][0-9][0-9][0|1][0-9])/
+    if ( ENV['MORPH_PERIOD'][0..3].to_i > Date.today.year.to_i )
+      ENV['MORPH_PERIOD'] = Date.today.year.to_s
+      puts 'changing invalid year input'
+    end
+
+    month = ENV['MORPH_PERIOD'][4..5].to_i
+    if ( month < 1 || month > 12 )
+      ENV['MORPH_PERIOD'] = Date.today.year.to_s + Date.today.month.to_s
+      puts 'changing invalid month input'
+    end
+
+    period = 'custom year and month: ' + ENV['MORPH_PERIOD']
+    start_date = Date.new(ENV['MORPH_PERIOD'][0..3].to_i, ENV['MORPH_PERIOD'][4..5].to_i, 1)
+    end_date   = Date.new(ENV['MORPH_PERIOD'][0..3].to_i, ENV['MORPH_PERIOD'][4..5].to_i + 1 , 1) - 1
   when 'lastmonth'
     period = 'lastmonth'
+    start_date = (Date.today - Date.today.mday) - (Date.today - Date.today.mday - 1).mday
+    end_date   = Date.today - Date.today.day
   when 'thismonth'
     period = 'thismonth'
+    start_date = (Date.today - Date.today.mday + 1)
+    end_date   = Date.today
   else
     period = (Date.today - 14).strftime("%d/%m/%Y")+'&2='+(Date.today).strftime("%d/%m/%Y")
+    period = 'thisweek'
+    start_date = Date.today - 14
+    end_date   = Date.today
 end
 
 puts "Collecting data from " + period

--- a/scraper.rb
+++ b/scraper.rb
@@ -32,6 +32,7 @@ def scrape_page(page, comment_url)
     }
     #p record
     if (ScraperWiki.select("* from data where `council_reference`='#{record['council_reference']}'").empty? rescue true)
+      puts "Saving record " + record['council_reference'] + ", " + record['address']
       ScraperWiki.save_sqlite(['council_reference'], record)
     else
       puts "Skipping already saved record " + record['council_reference']


### PR DESCRIPTION
In respond to #4, a better way for data recovery is included.

Set MORPH_PERIOD secret to `201808` should collect the missing data in August.

This doesn't resolve #3, however, the chances now hit more than 10 pages in a single day is very unlikely.

```
Date: 2018-08-30
 Scraping page 1...
 Saving record CA-6770/2018, 196-198 Jones Road BELLBIRD PARK QLD 4300
```

Happy to consider this fixes #3 and fixes #4
